### PR TITLE
fix Null adapter bug and add FileSystem adapter

### DIFF
--- a/bankersbox.js
+++ b/bankersbox.js
@@ -763,11 +763,55 @@
     };
   };
 
+  var BankersBoxFileSystemAdapter = function(filename) {
+    if (!(typeof(module) !== 'undefined' && module && module.exports)) {
+      throw("this does not appear to be a server context, consider a different storage adapter");
+    }
+    var store = {};
+    var fs = require('fs');
+
+    var init = function() {
+      if (fs.existsSync(filename)) {
+        var data = fs.readFileSync(filename, {encoding: 'utf8'});
+        if (data) {
+          store = JSON.parse(data);
+        }
+      }
+    };
+
+    var persist = function() {
+      fs.writeFileSync(filename, JSON.stringify(store), {encoding: 'utf8'});
+    };
+
+    init();
+
+    this.getItem = function(k) {
+      return store[k] || null;
+    };
+
+    this.storeItem = function(k, v) {
+      store[k] = v;
+      persist();
+    };
+
+    this.removeItem = function(k) {
+      delete store[k];
+      persist();
+    };
+
+    this.clear = function() {
+      store = {};
+      fs.unlinkSync(filename);
+    };
+  };
+
   ctx.BankersBox = BB;
   ctx.BankersBoxException = BankersBoxException;
   ctx.BankersBoxKeyException = BankersBoxKeyException;
   ctx.BankersBoxLocalStorageAdapter = BankersBoxLocalStorageAdapter;
   ctx.BankersBoxNullAdapter = BankersBoxNullAdapter;
+  ctx.BankersBoxFileSystemAdapter = BankersBoxFileSystemAdapter;
+
   if (ctx !== window) {
     ctx.mock_window = window;
   }

--- a/bankersbox.js
+++ b/bankersbox.js
@@ -2,7 +2,7 @@
  * @license MIT License
  *
  * Copyright (c) 2012 Twilio Inc.
- * 
+ *
  * Authors: Chad Etzel <chetzel@twilio.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -750,6 +750,7 @@
   var BankersBoxNullAdapter = function() {
 
     this.getItem = function(k) {
+      return null;
     };
 
     this.storeItem = function(k, v) {

--- a/tests/adapter_file_system.test.coffee
+++ b/tests/adapter_file_system.test.coffee
@@ -1,0 +1,23 @@
+assert = require "assert"
+fs = require "fs"
+{ BankersBox, BankersBoxFileSystemAdapter } = require "bankersbox"
+
+exports.testFileSystemAdapter =->
+  adapter = new BankersBoxFileSystemAdapter("./bb_file_adapter.dat")
+  assert.equal adapter.getItem("foo"), null, "test getItem"
+  assert.equal adapter.storeItem("foo", "bar"), undefined, "test storeItem"
+  assert.equal adapter.getItem("foo"), "bar", "test getItem after storeItem"
+  assert.equal adapter.removeItem("foo"), undefined, "test removeItem"
+  assert.equal adapter.getItem("foo"), null, "test getItem after removeItem"
+  assert.equal adapter.clear(), undefined, "test clear"
+
+exports.testBankersBoxWithFileSystemAdapter =->
+  filename = "./bb_file_test.dat"
+  adapter = new BankersBoxFileSystemAdapter(filename)
+  bb = new BankersBox(1, {adapter: adapter})
+  bb.flushdb()
+  assert.equal bb.set("foo", "bar"), "OK", "test set"
+  assert.equal bb.get("foo"), "bar", "test get"
+  assert.equal fs.existsSync(filename), true, "backing file should exist"
+  adapter.clear()
+  assert.equal fs.existsSync(filename), false, "backing file should not exist"

--- a/tests/adapter_null.test.coffee
+++ b/tests/adapter_null.test.coffee
@@ -1,5 +1,5 @@
 assert = require "assert"
-{ BankersBoxNullAdapter } = require "bankersbox"
+{ BankersBox, BankersBoxNullAdapter } = require "bankersbox"
 
 exports.testNullAdapter =->
   adapter = new BankersBoxNullAdapter()
@@ -7,3 +7,10 @@ exports.testNullAdapter =->
   assert.equal adapter.storeItem("foo", "bar"), undefined, "test storeItem"
   assert.equal adapter.removeItem("foo"), undefined, "test removeItem"
   assert.equal adapter.clear(), undefined, "test clear"
+
+exports.testBankersBoxWithNullAdapter =->
+  adapter = new BankersBoxNullAdapter()
+  bb = new BankersBox(1, {adapter: adapter})
+  bb.flushdb()
+  assert.equal bb.set("foo", "bar"), "OK", "test set"
+  assert.equal bb.get("foo"), "bar", "test get"

--- a/tests/bb_string.test.coffee
+++ b/tests/bb_string.test.coffee
@@ -12,7 +12,7 @@ exports.testSetAndGet = ->
   bb = new BankersBox(1)
   bb.flushdb()
   bb.set "foo", "bar"
-  assert.equal bb.get("foo"), "bar", "test set"
+  assert.equal bb.get("foo"), "bar", "test get"
 
 exports.testGetNull = ->
   bb = new BankersBox(1)


### PR DESCRIPTION
This fixes a bug in the Null adapter and adds a FileSystem adapter which is useful for persisting data on the filesystem when using BankersBox with node/serverside javascript processes.
