### PR TITLE
Fixed security exception being thrown when cookies are disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,16 @@ min: bankersbox.min.js
 
 test:
 	@echo "Testing bankersbox.js:"
-	@NODE_PATH=`pwd` expresso -s tests/*
+	@NODE_PATH=`pwd` ./node_modules/.bin/expresso -s tests/*.test.coffee
+	@NODE_PATH=`pwd` ./node_modules/.bin/expresso -s tests/*.test_special.coffee
 
 testmin: min
 	@mkdir -p src-min-tmp
 	@rm -f src-min-tmp/bankersbox.js
 	@ln -s ../bankersbox.min.js src-min-tmp/bankersbox.js
 	@echo "Testing MINIFIED file:"
-	@NODE_PATH=`pwd`/src-min-tmp expresso -s tests/*
+	@NODE_PATH=`pwd`/src-min-tmp ./node_modules/.bin/expresso -s tests/*
+	@NODE_PATH=`pwd`/src-min-tmp ./node_modules/.bin/expresso -s tests/*.test_special.coffee
 
 testall: test testmin
 
@@ -32,7 +34,7 @@ coverage:
 	rm -f src-tmp/bankersbox.js
 	ln -s ../bankersbox.js src-tmp/bankersbox.js
 	rm -rf src-cov
-	node-jscoverage src-tmp src-cov
-	NODE_PATH=`pwd`/src-cov expresso -s tests/*
+	./node_modules/.bin/node-jscoverage src-tmp src-cov
+	NODE_PATH=`pwd`/src-cov ./node_modules/.bin/expresso -s tests/*.test.coffee
 
 .PHONY: all clean min test testmin testall coverage

--- a/bankersbox.js
+++ b/bankersbox.js
@@ -31,6 +31,14 @@
     window = {};
   }
 
+  try {
+    // when cookies are disabled accessing `window.localStorage` throws ERR 18
+    window.localStorage;
+  }
+  catch (e) {
+    return;
+  }
+
   if (typeof(window.localStorage) === 'undefined' && ctx !== window) {
     // fake out localStorage functionality, mostly for testing purposes
     window.localStorage = {};

--- a/tests/bb_cookies_disabled.test_special.coffee
+++ b/tests/bb_cookies_disabled.test_special.coffee
@@ -1,0 +1,8 @@
+GLOBAL.window = {}
+Object.defineProperty window, 'localStorage', get: -> throw 'ERR'
+
+assert = require "assert"
+{ BankersBox } = require "bankersbox"
+
+exports.testWithCookiesDisabled = ->
+  assert.equal BankersBox, undefined, "BankersBox is expected to be undefined"


### PR DESCRIPTION
Module blows up when cookies are disabled in the browser settings. This addresses the issue by simply returning out of the module leaving it up to the user to determine how to handle that.
